### PR TITLE
Gihyeon week8

### DIFF
--- a/Gihyeon/Week4_7/Piumteo/demo/src/main/java/com/piumteo/server/domain/comment/controller/CommentController.java
+++ b/Gihyeon/Week4_7/Piumteo/demo/src/main/java/com/piumteo/server/domain/comment/controller/CommentController.java
@@ -1,12 +1,17 @@
 package com.piumteo.server.domain.comment.controller;
 
 import com.piumteo.server.domain.comment.dto.CommentCursorResponse;
+import com.piumteo.server.domain.comment.dto.CommentMutationResponse;
+import com.piumteo.server.domain.comment.dto.CreateGuestCommentRequest;
+import com.piumteo.server.domain.comment.dto.DeleteGuestCommentRequest;
+import com.piumteo.server.domain.comment.dto.UpdateGuestCommentRequest;
 import com.piumteo.server.domain.comment.exception.CommentCode;
 import com.piumteo.server.domain.comment.service.CommentService;
 import com.piumteo.server.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Positive;
@@ -17,7 +22,7 @@ import org.springframework.web.bind.annotation.*;
 
 @Tag(
         name = "댓글",
-        description = "장소 댓글 조회, 작성, 삭제 관련 API"
+        description = "장소 댓글 조회, 작성, 수정, 삭제 관련 API"
 )
 @Validated
 @RestController
@@ -71,6 +76,137 @@ public class CommentController {
                 .body(ApiResponse.onSuccess(
                         CommentCode.COMMENT_LIST_SEARCH_SUCCESS,
                         response
+                ));
+    }
+
+    @Operation(
+            summary = "비회원 댓글 작성",
+            description = """
+                    특정 장소에 비회원 댓글을 작성합니다.
+                    
+                    - 현재 로그인/인증 기능이 없으므로 비회원 댓글 작성만 우선 지원합니다.
+                    - displayNickname, guestPassword, content가 필요합니다.
+                    - guestPassword는 서버에서 해시 처리하여 저장합니다.
+                    
+                    TODO:
+                    - 인증 구현 후 accessToken이 있으면 회원 댓글 작성으로 분기합니다.
+                    - 회원 댓글 작성 시 displayNickname은 회원 닉네임을 복사하여 저장합니다.
+                    """
+    )
+    @PostMapping
+    public ResponseEntity<ApiResponse<CommentMutationResponse>> createGuestComment(
+            @Parameter(
+                    description = "댓글을 작성할 장소 ID",
+                    example = "1",
+                    required = true
+            )
+            @PathVariable @Positive Long placeId,
+
+            @Valid @RequestBody CreateGuestCommentRequest request
+    ) {
+        CommentMutationResponse response = commentService.createGuestComment(
+                placeId,
+                request
+        );
+
+        return ResponseEntity
+                .status(CommentCode.COMMENT_CREATE_SUCCESS.getHttpStatus())
+                .body(ApiResponse.onSuccess(
+                        CommentCode.COMMENT_CREATE_SUCCESS,
+                        response
+                ));
+    }
+
+    @Operation(
+            summary = "비회원 댓글 수정",
+            description = """
+                    특정 장소의 비회원 댓글 내용을 수정합니다.
+                    
+                    - 현재 로그인/인증 기능이 없으므로 비회원 댓글 수정만 우선 지원합니다.
+                    - guestPassword가 기존 댓글 비밀번호와 일치해야 수정할 수 있습니다.
+                    - commentId가 placeId에 속한 댓글인지 함께 검증합니다.
+                    
+                    TODO:
+                    - 인증 구현 후 회원 댓글이면 현재 로그인 사용자 ID와 댓글 작성자 ID를 비교합니다.
+                    - 회원 댓글 수정 시 guestPassword 없이 content만 받도록 분기합니다.
+                    """
+    )
+    @PatchMapping("/{commentId}")
+    public ResponseEntity<ApiResponse<CommentMutationResponse>> updateGuestComment(
+            @Parameter(
+                    description = "댓글이 속한 장소 ID",
+                    example = "1",
+                    required = true
+            )
+            @PathVariable @Positive Long placeId,
+
+            @Parameter(
+                    description = "수정할 댓글 ID",
+                    example = "15",
+                    required = true
+            )
+            @PathVariable @Positive Long commentId,
+
+            @Valid @RequestBody UpdateGuestCommentRequest request
+    ) {
+        CommentMutationResponse response = commentService.updateGuestComment(
+                placeId,
+                commentId,
+                request
+        );
+
+        return ResponseEntity
+                .status(CommentCode.COMMENT_UPDATE_SUCCESS.getHttpStatus())
+                .body(ApiResponse.onSuccess(
+                        CommentCode.COMMENT_UPDATE_SUCCESS,
+                        response
+                ));
+    }
+
+    @Operation(
+            summary = "비회원 댓글 삭제",
+            description = """
+                    특정 장소의 비회원 댓글을 삭제합니다.
+                    
+                    - 현재 로그인/인증 기능이 없으므로 비회원 댓글 삭제만 우선 지원합니다.
+                    - guestPassword가 기존 댓글 비밀번호와 일치해야 삭제할 수 있습니다.
+                    - 실제 DB row를 제거하지 않고 deletedAt을 채우는 soft delete 방식입니다.
+                    - commentId가 placeId에 속한 댓글인지 함께 검증합니다.
+                    
+                    TODO:
+                    - 인증 구현 후 회원 댓글이면 현재 로그인 사용자 ID와 댓글 작성자 ID를 비교합니다.
+                    - 회원 댓글 삭제 시 request body 없이 삭제할 수 있도록 분기합니다.
+                    """
+    )
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<ApiResponse<Void>> deleteGuestComment(
+            @Parameter(
+                    description = "댓글이 속한 장소 ID",
+                    example = "1",
+                    required = true
+            )
+            @PathVariable @Positive Long placeId,
+
+            @Parameter(
+                    description = "삭제할 댓글 ID",
+                    example = "15",
+                    required = true
+            )
+            @PathVariable @Positive Long commentId,
+
+            @Valid @RequestBody DeleteGuestCommentRequest request
+    ) {
+        commentService.deleteGuestComment(
+                placeId,
+                commentId,
+                request
+        );
+
+        return ResponseEntity
+                .status(CommentCode.COMMENT_DELETE_SUCCESS.getHttpStatus())
+                .body(ApiResponse.onSuccess(
+                        CommentCode.COMMENT_DELETE_SUCCESS,
+                        null
                 ));
     }
 

--- a/Gihyeon/Week4_7/Piumteo/demo/src/main/java/com/piumteo/server/domain/comment/dto/CommentMutationResponse.java
+++ b/Gihyeon/Week4_7/Piumteo/demo/src/main/java/com/piumteo/server/domain/comment/dto/CommentMutationResponse.java
@@ -1,0 +1,21 @@
+package com.piumteo.server.domain.comment.dto;
+
+import com.piumteo.server.domain.comment.entity.CommentAuthorType;
+import com.piumteo.server.domain.comment.entity.PlaceComment;
+
+public record CommentMutationResponse(
+        Long placeCommentId,
+        CommentAuthorType commentAuthorType,
+        String displayNickname,
+        String content
+) {
+
+    public static CommentMutationResponse from(PlaceComment comment) {
+        return new CommentMutationResponse(
+                comment.getId(),
+                comment.getAuthorType(),
+                comment.getDisplayNickname(),
+                comment.getContent()
+        );
+    }
+}

--- a/Gihyeon/Week4_7/Piumteo/demo/src/main/java/com/piumteo/server/domain/comment/dto/CreateGuestCommentRequest.java
+++ b/Gihyeon/Week4_7/Piumteo/demo/src/main/java/com/piumteo/server/domain/comment/dto/CreateGuestCommentRequest.java
@@ -10,7 +10,7 @@ public record CreateGuestCommentRequest(
         String displayNickname,
 
         @NotBlank(message = "게스트 비밀번호는 필수입니다.")
-        @Size(min = 4, max = 30, message = "게스트 비밀번호는 4자 이상 30자 이하여야 합니다.")
+        @Size(min = 4, max = 50, message = "게스트 비밀번호는 4자 이상 50자 이하여야 합니다.")
         String guestPassword,
 
         @NotBlank(message = "댓글 내용은 필수입니다.")

--- a/Gihyeon/Week4_7/Piumteo/demo/src/main/java/com/piumteo/server/domain/comment/dto/UpdateGuestCommentRequest.java
+++ b/Gihyeon/Week4_7/Piumteo/demo/src/main/java/com/piumteo/server/domain/comment/dto/UpdateGuestCommentRequest.java
@@ -3,10 +3,14 @@ package com.piumteo.server.domain.comment.dto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
-public record DeleteGuestCommentRequest(
+public record UpdateGuestCommentRequest(
 
         @NotBlank(message = "게스트 비밀번호는 필수입니다.")
         @Size(min = 4, max = 50, message = "게스트 비밀번호는 4자 이상 50자 이하여야 합니다.")
-        String guestPassword
+        String guestPassword,
+
+        @NotBlank(message = "댓글 내용은 필수입니다.")
+        @Size(max = 500, message = "댓글은 500자 이하여야 합니다.")
+        String content
 ) {
 }

--- a/Gihyeon/Week4_7/Piumteo/demo/src/main/java/com/piumteo/server/domain/comment/dto/UpdateMemberCommentRequest.java
+++ b/Gihyeon/Week4_7/Piumteo/demo/src/main/java/com/piumteo/server/domain/comment/dto/UpdateMemberCommentRequest.java
@@ -1,0 +1,12 @@
+package com.piumteo.server.domain.comment.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record UpdateMemberCommentRequest(
+
+        @NotBlank(message = "댓글 내용은 필수입니다.")
+        @Size(max = 500, message = "댓글은 500자 이하여야 합니다.")
+        String content
+) {
+}

--- a/Gihyeon/Week4_7/Piumteo/demo/src/main/java/com/piumteo/server/domain/comment/entity/PlaceComment.java
+++ b/Gihyeon/Week4_7/Piumteo/demo/src/main/java/com/piumteo/server/domain/comment/entity/PlaceComment.java
@@ -98,4 +98,9 @@ public class PlaceComment extends BaseEntity {
     public boolean isGuestComment() {
         return this.authorType == CommentAuthorType.GUEST;
     }
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
+
 }

--- a/Gihyeon/Week4_7/Piumteo/demo/src/main/java/com/piumteo/server/domain/comment/exception/CommentCode.java
+++ b/Gihyeon/Week4_7/Piumteo/demo/src/main/java/com/piumteo/server/domain/comment/exception/CommentCode.java
@@ -11,14 +11,14 @@ public enum CommentCode implements ErrorCode {
 
     COMMENT_LIST_SEARCH_SUCCESS(
             HttpStatus.OK,
-            "COMMENT_200_001",
+            "COMMENT_200_000",
             "댓글 목록 조회에 성공했습니다."
     ),
 
-    COMMENT_CREATE_SUCCESS(
-            HttpStatus.CREATED,
-            "COMMENT_201_001",
-            "댓글 작성에 성공했습니다."
+    COMMENT_UPDATE_SUCCESS(
+            HttpStatus.OK,
+            "COMMENT_200_001",
+            "댓글 수정에 성공했습니다."
     ),
 
     COMMENT_DELETE_SUCCESS(
@@ -27,33 +27,39 @@ public enum CommentCode implements ErrorCode {
             "댓글 삭제에 성공했습니다."
     ),
 
+    COMMENT_CREATE_SUCCESS(
+            HttpStatus.CREATED,
+            "COMMENT_201_001",
+            "댓글 작성에 성공했습니다."
+    ),
+
     COMMENT_NOT_FOUND(
             HttpStatus.NOT_FOUND,
             "COMMENT_404_001",
-            "댓글을 찾을 수 없습니다."
+            "존재하지 않는 댓글입니다."
     ),
 
-    COMMENT_ALREADY_DELETED(
-            HttpStatus.CONFLICT,
-            "COMMENT_409_001",
-            "이미 삭제된 댓글입니다."
-    ),
-
-    INVALID_GUEST_PASSWORD(
-            HttpStatus.BAD_REQUEST,
-            "COMMENT_400_001",
-            "게스트 비밀번호가 일치하지 않습니다."
-    ),
-
-    UNAUTHORIZED_COMMENT_DELETE(
+    COMMENT_UPDATE_FORBIDDEN(
             HttpStatus.FORBIDDEN,
             "COMMENT_403_001",
-            "댓글을 삭제할 권한이 없습니다."
+            "해당 댓글을 수정할 권한이 없습니다."
+    ),
+
+    COMMENT_DELETE_FORBIDDEN(
+            HttpStatus.FORBIDDEN,
+            "COMMENT_403_002",
+            "해당 댓글을 삭제할 권한이 없습니다."
+    ),
+
+    COMMENT_PASSWORD_MISMATCH(
+            HttpStatus.FORBIDDEN,
+            "COMMENT_403_003",
+            "댓글 비밀번호가 일치하지 않습니다."
     ),
 
     INVALID_COMMENT_AUTHOR_TYPE(
             HttpStatus.BAD_REQUEST,
-            "COMMENT_400_002",
+            "COMMENT_400_001",
             "댓글 작성자 타입이 올바르지 않습니다."
     );
 

--- a/Gihyeon/Week4_7/Piumteo/demo/src/main/java/com/piumteo/server/domain/comment/repository/PlaceCommentRepository.java
+++ b/Gihyeon/Week4_7/Piumteo/demo/src/main/java/com/piumteo/server/domain/comment/repository/PlaceCommentRepository.java
@@ -11,6 +11,11 @@ public interface PlaceCommentRepository extends JpaRepository<PlaceComment, Long
 
     Optional<PlaceComment> findByIdAndDeletedAtIsNull(Long id);
 
+    Optional<PlaceComment> findByIdAndPlace_IdAndDeletedAtIsNull(
+            Long id,
+            Long placeId
+    );
+
     List<PlaceComment> findByPlace_IdAndDeletedAtIsNullOrderByIdDesc(
             Long placeId,
             Pageable pageable

--- a/Gihyeon/Week4_7/Piumteo/demo/src/main/java/com/piumteo/server/domain/comment/service/CommentService.java
+++ b/Gihyeon/Week4_7/Piumteo/demo/src/main/java/com/piumteo/server/domain/comment/service/CommentService.java
@@ -1,11 +1,13 @@
 package com.piumteo.server.domain.comment.service;
 
 import com.piumteo.server.domain.comment.dto.CommentCursorResponse;
+import com.piumteo.server.domain.comment.dto.CommentMutationResponse;
 import com.piumteo.server.domain.comment.dto.CommentResponse;
-import com.piumteo.server.domain.comment.dto.CreateCommentResponse;
 import com.piumteo.server.domain.comment.dto.CreateGuestCommentRequest;
 import com.piumteo.server.domain.comment.dto.CreateMemberCommentRequest;
 import com.piumteo.server.domain.comment.dto.DeleteGuestCommentRequest;
+import com.piumteo.server.domain.comment.dto.UpdateGuestCommentRequest;
+import com.piumteo.server.domain.comment.dto.UpdateMemberCommentRequest;
 import com.piumteo.server.domain.comment.entity.PlaceComment;
 import com.piumteo.server.domain.comment.exception.CommentCode;
 import com.piumteo.server.domain.comment.exception.CommentException;
@@ -37,11 +39,12 @@ public class CommentService {
     private final PasswordEncoder passwordEncoder;
 
     @Transactional
-    public CreateCommentResponse createMemberComment(
+    public CommentMutationResponse createMemberComment(
             Long placeId,
             Long userId,
             CreateMemberCommentRequest request
     ) {
+        // TODO 인증 구현 후 Controller의 @AuthenticationPrincipal에서 userId를 꺼내 전달
         Place place = placeService.getActivePlace(placeId);
         User user = userService.getActiveUser(userId);
 
@@ -53,12 +56,11 @@ public class CommentService {
         );
 
         PlaceComment savedComment = placeCommentRepository.save(comment);
-
-        return CreateCommentResponse.from(savedComment.getId());
+        return CommentMutationResponse.from(savedComment);
     }
 
     @Transactional
-    public CreateCommentResponse createGuestComment(
+    public CommentMutationResponse createGuestComment(
             Long placeId,
             CreateGuestCommentRequest request
     ) {
@@ -74,19 +76,58 @@ public class CommentService {
         );
 
         PlaceComment savedComment = placeCommentRepository.save(comment);
+        return CommentMutationResponse.from(savedComment);
+    }
 
-        return CreateCommentResponse.from(savedComment.getId());
+    @Transactional
+    public CommentMutationResponse updateMemberComment(
+            Long placeId,
+            Long commentId,
+            Long userId,
+            UpdateMemberCommentRequest request
+    ) {
+        // TODO 인증 구현 후 Controller의 @AuthenticationPrincipal에서 userId를 꺼내 전달
+        PlaceComment comment = getActiveCommentInPlace(placeId, commentId);
+
+        if (!comment.isWrittenByMember(userId)) {
+            throw new CommentException(CommentCode.COMMENT_UPDATE_FORBIDDEN);
+        }
+
+        comment.updateContent(request.content());
+
+        return CommentMutationResponse.from(comment);
+    }
+
+    @Transactional
+    public CommentMutationResponse updateGuestComment(
+            Long placeId,
+            Long commentId,
+            UpdateGuestCommentRequest request
+    ) {
+        PlaceComment comment = getActiveCommentInPlace(placeId, commentId);
+
+        if (!comment.isGuestComment()) {
+            throw new CommentException(CommentCode.COMMENT_UPDATE_FORBIDDEN);
+        }
+
+        validateGuestPassword(comment, request.guestPassword());
+
+        comment.updateContent(request.content());
+
+        return CommentMutationResponse.from(comment);
     }
 
     @Transactional
     public void deleteMemberComment(
+            Long placeId,
             Long commentId,
             Long userId
     ) {
-        PlaceComment comment = getActiveComment(commentId);
+        // TODO 인증 구현 후 Controller의 @AuthenticationPrincipal에서 userId를 꺼내 전달
+        PlaceComment comment = getActiveCommentInPlace(placeId, commentId);
 
         if (!comment.isWrittenByMember(userId)) {
-            throw new CommentException(CommentCode.UNAUTHORIZED_COMMENT_DELETE);
+            throw new CommentException(CommentCode.COMMENT_DELETE_FORBIDDEN);
         }
 
         comment.delete();
@@ -94,23 +135,17 @@ public class CommentService {
 
     @Transactional
     public void deleteGuestComment(
+            Long placeId,
             Long commentId,
             DeleteGuestCommentRequest request
     ) {
-        PlaceComment comment = getActiveComment(commentId);
+        PlaceComment comment = getActiveCommentInPlace(placeId, commentId);
 
         if (!comment.isGuestComment()) {
-            throw new CommentException(CommentCode.UNAUTHORIZED_COMMENT_DELETE);
+            throw new CommentException(CommentCode.COMMENT_DELETE_FORBIDDEN);
         }
 
-        boolean passwordMatches = passwordEncoder.matches(
-                request.guestPassword(),
-                comment.getGuestPasswordHash()
-        );
-
-        if (!passwordMatches) {
-            throw new CommentException(CommentCode.INVALID_GUEST_PASSWORD);
-        }
+        validateGuestPassword(comment, request.guestPassword());
 
         comment.delete();
     }
@@ -183,8 +218,30 @@ public class CommentService {
         return Math.min(size, MAX_COMMENT_PAGE_SIZE);
     }
 
-    private PlaceComment getActiveComment(Long commentId) {
-        return placeCommentRepository.findByIdAndDeletedAtIsNull(commentId)
+    private PlaceComment getActiveCommentInPlace(
+            Long placeId,
+            Long commentId
+    ) {
+        placeService.getActivePlace(placeId);
+
+        return placeCommentRepository.findByIdAndPlace_IdAndDeletedAtIsNull(
+                        commentId,
+                        placeId
+                )
                 .orElseThrow(() -> new CommentException(CommentCode.COMMENT_NOT_FOUND));
+    }
+
+    private void validateGuestPassword(
+            PlaceComment comment,
+            String rawPassword
+    ) {
+        boolean passwordMatches = passwordEncoder.matches(
+                rawPassword,
+                comment.getGuestPasswordHash()
+        );
+
+        if (!passwordMatches) {
+            throw new CommentException(CommentCode.COMMENT_PASSWORD_MISMATCH);
+        }
     }
 }


### PR DESCRIPTION
## 📌 개요 (Summary)
- 댓글 작성, 수정, 삭제 기능을 추가했습니다.
- 비회원 댓글은 비밀번호 검증 후 수정/삭제되도록 구현했습니다.
- 댓글 삭제는 실제 삭제가 아닌 `deletedAt` 기반 Soft Delete 방식으로 처리했습니다.

## 🛠️ 변경 사항 (Changes)
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 업데이트
- [ ] 기타

## 🚀 변경사항(상세)
1. 댓글 작성 API 추가
   - 비회원 댓글 작성 기능 구현
   - 비밀번호는 해시 처리 후 저장

2. 댓글 수정 API 추가
   - 비회원 댓글 수정 시 비밀번호 검증
   - 댓글 내용만 수정 가능

3. 댓글 삭제 API 추가
   - 비회원 댓글 삭제 시 비밀번호 검증
   - `deletedAt` 값을 채우는 Soft Delete 방식 적용

4. 댓글 조회/수정/삭제 검증 보완
   - `placeId`와 `commentId`를 함께 검증
   - 삭제된 댓글은 조회 및 수정/삭제 대상에서 제외

5. 인증 관련 TODO 처리
   - 현재 인증 기능이 없어 회원 댓글 CUD는 TODO로 분리
   - 추후 인증 구현 후 현재 사용자 ID 기반 권한 검증 예정

## 🔗 관련 이슈
- 없음

## ✅ 체크리스트
- [x] 로컬에서 빌드 확인
- [x] 코드 리뷰 준비 완료

## 📎 참고 자료
- 없음
